### PR TITLE
Integrate MATCH clause with PostgreSQL and AGE extension

### DIFF
--- a/command.h
+++ b/command.h
@@ -29,6 +29,11 @@ extern backslashResult HandleSlashCmds(PsqlScanState scan_state,
 									   PQExpBuffer query_buf,
 									   PQExpBuffer previous_buf);
 
+extern backslashResult HandleCypherCmds(PsqlScanState scan_state,
+									   ConditionalStack cstack,
+									   PQExpBuffer query_buf,
+									   PQExpBuffer previous_buf);
+
 extern int	process_file(char *filename, bool use_relative_path);
 
 extern bool do_pset(const char *param,

--- a/cypher.l
+++ b/cypher.l
@@ -40,7 +40,8 @@
 
 [0-9]+ { yylval.int_val = atoi(yytext); return INTEGER; }
 [a-zA-Z][a-zA-Z0-9_]* { yylval.str_val = strdup(yytext); return IDENTIFIER; }
-"([^\"]|\.)*" { yylval.str_val = strdup(yytext); return STRING; }
+\"([^\"]|\.)*\" { yylval.str_val = strdup(yytext); return STRING; }
+[ \t\\\\]+   { /* ignore spaces, tabs, and backslashes */; }
 . { return UNKNOWN; }
 
 %%

--- a/cypherscan.h
+++ b/cypherscan.h
@@ -9,6 +9,6 @@
 #define CYPHERSCAN_H
 
 #include "fe_utils/psqlscan.h"
-void psql_scan_cypher_command(PsqlScanState state);
+char* psql_scan_cypher_command(PsqlScanState state);
 
 #endif   /* CYPHERSCAN_H */

--- a/mainloop.c
+++ b/mainloop.c
@@ -433,6 +433,11 @@ MainLoop(FILE *source)
 					pg_send_history(history_buf);
 					line_saved_in_history = true;
 				}
+                                
+                                HandleCypherCmds(scan_state,
+                                                            cond_stack,
+                                                            query_buf,
+                                                            previous_buf);
 
 				/* execute query unless we're in an inactive \if branch */
 				if (conditional_active(cond_stack))
@@ -491,8 +496,7 @@ MainLoop(FILE *source)
 					pg_append_history(line, history_buf);
 					pg_send_history(history_buf);
 					line_saved_in_history = true;
-				}
-				psql_scan_cypher_command(scan_state);
+				}                              
 
 				/* execute backslash command */
 				slashCmdStatus = HandleSlashCmds(scan_state,


### PR DESCRIPTION
This commit is a sample for integrating the MATCH clause with PostgreSQL by creating a command to convert a Cypher command into a SQL command in Apache AGE style. This is based on HandleSlashCmds and psql_scan_slash_command PostgreSQL functions. Since it is a sample, it only returns one agtype as result. It also removes the backslash command.

For compiling the code, run `make`.

To run the code:

```
createdb ageslqldb // create database
pg_ctl -D agesqldb -l logfile start // start database process
./agesql agesqldb // run agesql
```

Query example:

```
agesqldb=# MATCH (p) RETURN p;

// will be converted to
SELECT * FROM cypher($$MATCH (p) RETURN p;$$) AS (result agtype);
```