### PR TITLE
Remove backslash command

### DIFF
--- a/cypher.y
+++ b/cypher.y
@@ -12,7 +12,7 @@
 #include "cypherscan.h"
 #include "cypher.tab.h"
 
-void yyerror(char const *s);
+void yyerror(char* data, char const *s);
 
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 
@@ -21,7 +21,7 @@ typedef struct {
     int int_val;
 } yyval;
 
-int yylex(void);
+int yylex(char* data);
 
 int order_clause_direction = 1; // 1 for ascending, -1 for descending
 %}
@@ -39,12 +39,14 @@ int order_clause_direction = 1; // 1 for ascending, -1 for descending
 %left PIPE
 %left ARROW
 
+%param {char* data}
+
 %start statement
 
 %%
 
 statement:
-    { /* no action needed */ }
+    query SEMICOLON
     ;
 
 query:
@@ -161,13 +163,13 @@ sort_direction_opt:
 
 %%
 
-void yyerror(char const *s)
+void yyerror(char* data, char const *s)
 {
     fprintf(stderr, "Parser error: %s\n", s);
 }
 
-void psql_scan_cypher_command(PsqlScanState state)
+void psql_scan_cypher_command(char *data)
 {
-	yylex();
+    yyparse(data);
 }
 

--- a/cypherscan.h
+++ b/cypherscan.h
@@ -9,6 +9,6 @@
 #define CYPHERSCAN_H
 
 #include "fe_utils/psqlscan.h"
-void psql_scan_cypher_command(PsqlScanState state);
+void psql_scan_cypher_command(char* data);
 
 #endif   /* CYPHERSCAN_H */

--- a/mainloop.c
+++ b/mainloop.c
@@ -433,6 +433,8 @@ MainLoop(FILE *source)
 					pg_send_history(history_buf);
 					line_saved_in_history = true;
 				}
+                                
+                                psql_scan_cypher_command(query_buf->data);
 
 				/* execute query unless we're in an inactive \if branch */
 				if (conditional_active(cond_stack))
@@ -492,7 +494,6 @@ MainLoop(FILE *source)
 					pg_send_history(history_buf);
 					line_saved_in_history = true;
 				}
-				psql_scan_cypher_command(query_buf->data);
 
 				/* execute backslash command */
 				slashCmdStatus = HandleSlashCmds(scan_state,


### PR DESCRIPTION
This PR removes the backslash command required to run the MATCH clause.

For compiling the code, run `make`.

To run the code:

```
createdb ageslqldb // create database
pg_ctl -D agesqldb -l logfile start // start database process
./agesql agesqldb // run agesql
```

Query examples:

```
agesqldb=# MATCH (p) RETURN p;
```
or

```
agesqldb=# MATCH (p)
agesqldb-# RETURN p;
```

Since the MATCH clause is not integrated yet, there is no return from the command.