### PR TITLE
Add CREATE GRAPH function

### DIFF
--- a/cypherscan.h
+++ b/cypherscan.h
@@ -10,6 +10,6 @@
 
 #include "fe_utils/psqlscan.h"
 bool psql_scan_cypher_command(char *);
-char *convert_to_psql_command(char *);
+char *convert_to_psql_command(char *, bool is_command);
 
 #endif   /* CYPHERSCAN_H */

--- a/mainloop.c
+++ b/mainloop.c
@@ -44,6 +44,7 @@ MainLoop(FILE *source)
 	int			added_nl_pos;
 	bool		success;
 	bool		line_saved_in_history;
+        bool            is_command = true;
 	volatile int successResult = EXIT_SUCCESS;
 	volatile backslashResult cypherCmdStatus = PSQL_CMD_UNKNOWN;
 	volatile backslashResult slashCmdStatus = PSQL_CMD_UNKNOWN;
@@ -440,6 +441,9 @@ MainLoop(FILE *source)
 					/* handle cypher match command */
 					if (pg_strncasecmp(query_buf->data, "MATCH", 5) == 0)
 					{
+                                                /* States that this is a Cypher command. This will be used to
+                                                 * convert to the correct psql command */
+                                                is_command = true;
 						cypherCmdStatus = HandleCypherCmds(scan_state,
 											cond_stack,
 											query_buf,
@@ -450,10 +454,14 @@ MainLoop(FILE *source)
 						if (cypherCmdStatus == PSQL_CMD_SEND)
 						{
 							//char *qry = convert_to_psql_command(query_buf->data);
-							success = SendQuery(convert_to_psql_command(query_buf->data));
+							success = SendQuery(convert_to_psql_command(query_buf->data, is_command));
 						}
 					}
-
+                                        else if (pg_strncasecmp(query_buf->data, "CREATE GRAPH", 12) == 0)
+                                        {                                         
+                                            is_command = false;
+                                            success = SendQuery(convert_to_psql_command(query_buf->data, is_command));						
+                                        }
 					else
 						success = SendQuery(query_buf->data);
 


### PR DESCRIPTION
This PR adds the CREATE GRAPH function. The requirements to compile this code are:

1. Have Postgres 15 installed.
2. Setup the following variables:

```
export PATH={path-to-pgsql-15}/bin:$PATH`
export USE_PGXS=TRUE
```
Then, run `make`.

The requirements to run the code are:

1. Have Postgres 12 installed.
2. Have Apache AGE for Postgres 12 installed.
3. Setup PATH with the path to Postgres 12.
4. Create a new database.
5. Run agesql.

Example:

```
export PATH={path-to-pgsql-12}/bin:$PATH`
createdb ageslqldb
pg_ctl -D agesqldb -l logfile start
./agesql agesqldb
```

To create a new graph, setup Apache AGE for Postgres 12 in the database. Example for the clause `CREATE GRAPH new_graph;`:

```
agesqldb=# CREATE EXTENSION age;
CREATE EXTENSION
agesqldb=# LOAD 'age';
LOAD
agesqldb=# SET search_path = ag_catalog, "$user", public;
SET
agesqldb=# CREATE GRAPH new_graph;
NOTICE:  graph "new_graph" has been created
 create_graph
--------------

(1 row)
```