### PR TITLE
Support for label inheritance, SET GRAPH, and SET GRAPH_PATH:

### DIFF
--- a/cypher.l
+++ b/cypher.l
@@ -49,7 +49,7 @@
 "IF"|"if" { return IF; }
 "CASCADE"|"cascade" { return CASCADE; }
 "ALTER"|"alter" { return ALTER; }
-"RENAME"|"rename" { return RENAME; }
+"RENAME TO"|"rename to" { return RENAME; }
 "EXPLAIN"|"explain" { return EXPLAIN; }
 "MERGE"|"merge" { return MERGE; }
 "LOAD"|"load" { return LOAD; }
@@ -85,10 +85,11 @@
 "ALL"|"all" { return ALL; }
 "SELECT"|"select" { return SELECT; }
 "FROM"|"from" { return FROM; }
+"GRAPH_PATH"|"graph_path" { return GRAPH_PATH; }
 
-[0-9]+ { yylval.int_val = atoi(yytext); return INTEGER; }
-[0-9]+"."[0-9]+ { yylval.float_val = atof(yytext); return FLOAT; }
-[a-zA-Z][a-zA-Z0-9_.]* { yylval.str_val = strdup(yytext); return IDENTIFIER; }
+[-+]?[0-9]+ { yylval.int_val = atoi(yytext); return INTEGER; }
+[-+]?[0-9]+"."[0-9]+ { yylval.float_val = atof(yytext); return FLOAT; }
+[a-zA-Z][a-zA-Z0-9_.*]* { yylval.str_val = strdup(yytext); return IDENTIFIER; }
 ("\"")[^"]*("\"")|("\'")[^']*("\'") { yylval.str_val = strdup(yytext); return STRING; }
 ("=")|("!=")|("<=")|(">=")|("<")|(">")|("<>") { yylval.str_val = strdup(yytext); return COMPARATOR; }
 . { return UNKNOWN; }

--- a/mainloop.c
+++ b/mainloop.c
@@ -444,7 +444,8 @@ MainLoop(FILE *source)
 							pg_strncasecmp(query_buf->data, "CREATE", 6) == 0 ||
 							pg_strncasecmp(query_buf->data, "DROP", 4) == 0 ||
 							pg_strncasecmp(query_buf->data, "ALTER", 5) == 0 ||
-							pg_strncasecmp(query_buf->data, "LOAD", 4) == 0)
+							pg_strncasecmp(query_buf->data, "LOAD", 4) == 0  ||
+                                                        pg_strncasecmp(query_buf->data, "SET", 3) == 0) 
 					{
 						cypherCmdStatus = HandleCypherCmds(scan_state,
 											cond_stack,


### PR DESCRIPTION
The following clauses define the default graph:
`SET GRAPH_PATH = new_graph;`
`SET GRAPH = new_graph;`

When running the following query, the default graph will be selected:
```
MATCH (n) RETURN n;

INFO: SELECT * FROM cypher('new_graph', $$ MATCH (n) RETURN n $$) AS (n agtype);
```
This PR supports label inheritance for edges and vertices:
```
CREATE VLABEL v0;
CREATE VLABEL v00 INHERITS (v0);
```
Returning message: `INFO: SELECT * FROM create_vlabel('new_graph', 'v00', ARRAY['v0']);`

This PR also fixes some errors with CREATE VLABEL, CREATE ELABEL, other CREATE-related clauses, and segmentation fault errors.